### PR TITLE
Add blinking caret to amount inputs

### DIFF
--- a/src/components/AddExpenseDialog.tsx
+++ b/src/components/AddExpenseDialog.tsx
@@ -56,6 +56,7 @@ export function AddExpenseDialog({
   const [exitChar, setExitChar] = useState<string | null>(null)
   const [exitKey, setExitKey] = useState(0)
   const [shaking, setShaking] = useState(false)
+  const [focused, setFocused] = useState(false)
   const prevAmountRef = useRef('')
   const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -171,7 +172,7 @@ export function AddExpenseDialog({
 
   const currencySymbol = currency === 'EUR' ? '€' : 'лв.'
   const formatted = formatAmountInput(amount)
-  const amountFontSize = formatted.length > 9 ? 24 : formatted.length > 6 ? 32 : 40
+  const amountFontSize = formatted.length > 10 ? 24 : formatted.length > 9 ? 32 : 40
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -237,10 +238,17 @@ export function AddExpenseDialog({
                     }
                     setAmount(result)
                   }}
+                  onFocus={() => setFocused(true)}
+                  onBlur={() => setFocused(false)}
                   autoFocus
                   className="absolute inset-0 w-full opacity-0 border-none outline-none cursor-text"
                 />
               </div>
+              {/* Blinking caret — outside relative container so it doesn't shift layout */}
+              <span
+                className={`pointer-events-none font-light ${focused ? 'animate-caret' : 'opacity-0'}`}
+                style={{ fontSize: amountFontSize, lineHeight: 1 }}
+              >|</span>
               <span className="font-bold leading-none pointer-events-none" style={{ fontSize: amountFontSize }}>
                 {currencySymbol}
               </span>

--- a/src/components/YearlyExpensesSection.tsx
+++ b/src/components/YearlyExpensesSection.tsx
@@ -41,6 +41,7 @@ export function YearlyExpensesSection({
   const [exitChar, setExitChar] = useState<string | null>(null)
   const [exitKey, setExitKey] = useState(0)
   const [shaking, setShaking] = useState(false)
+  const [focused, setFocused] = useState(false)
   const prevAmountRef = useRef('')
   const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -113,7 +114,7 @@ export function YearlyExpensesSection({
 
   const currencySymbol = currency === 'EUR' ? '€' : 'лв.'
   const formatted = formatAmountInput(amount)
-  const amountFontSize = formatted.length > 9 ? 24 : formatted.length > 6 ? 32 : 40
+  const amountFontSize = formatted.length > 10 ? 24 : formatted.length > 9 ? 32 : 40
 
   return (
     <Card className="h-full py-0">
@@ -222,10 +223,17 @@ export function YearlyExpensesSection({
                       }
                       setAmount(result)
                     }}
+                    onFocus={() => setFocused(true)}
+                    onBlur={() => setFocused(false)}
                     autoFocus
                     className="absolute inset-0 w-full opacity-0 border-none outline-none cursor-text"
                   />
                 </div>
+                {/* Blinking caret — outside relative container so it doesn't shift layout */}
+                <span
+                  className={`pointer-events-none font-light ${focused ? 'animate-caret' : 'opacity-0'}`}
+                  style={{ fontSize: amountFontSize, lineHeight: 1 }}
+                >|</span>
                 <span className="font-bold leading-none pointer-events-none" style={{ fontSize: amountFontSize }}>
                   {currencySymbol}
                 </span>

--- a/src/index.css
+++ b/src/index.css
@@ -161,6 +161,15 @@
   animation: shake 0.4s ease-in-out;
 }
 
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+.animate-caret {
+  animation: blink 1s step-end infinite;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;


### PR DESCRIPTION
## Summary
- Adds a blinking cursor to the custom amount displays in AddExpenseDialog and YearlyExpensesSection
- Caret is always rendered (opacity-0 when unfocused) to prevent layout shifts between states
- Adjusts font size breakpoints to keep text larger for longer inputs

## Test plan
- [ ] Open Add Expense dialog — verify blinking caret appears after the number
- [ ] Type/delete digits — caret stays at the end, no layout jumps
- [ ] Click outside the input area (e.g. on category dropdown) — caret disappears
- [ ] Open Yearly Expense dialog — same caret behavior
- [ ] Verify no visual shift between focused and unfocused states

🤖 Generated with [Claude Code](https://claude.com/claude-code)